### PR TITLE
Switch to NUnit4 because that's what we use everywhere

### DIFF
--- a/SimpleBusTests/GlobalUsings.cs
+++ b/SimpleBusTests/GlobalUsings.cs
@@ -1,3 +1,3 @@
 global using SimpleBus;
 global using SimpleBusTests.Helpers;
-global using Xunit;
+global using NUnit.Framework;

--- a/SimpleBusTests/SimpleBusTests.csproj
+++ b/SimpleBusTests/SimpleBusTests.csproj
@@ -10,11 +10,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" PrivateAssets="all" />
+        <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-        <PackageReference Include="xunit" Version="2.9.0" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" PrivateAssets="all" />
-        <PackageReference Include="coverlet.collector" Version="6.0.2" PrivateAssets="all" />
+        <PackageReference Include="NUnit" Version="4.2.2" />
+        <PackageReference Include="NUnit.Analyzers" Version="4.3.0" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/SimpleBusTests/Tests.cs
+++ b/SimpleBusTests/Tests.cs
@@ -1,8 +1,9 @@
 namespace SimpleBusTests;
 
-public static class Tests
+[TestFixture]
+public class Tests
 {
-    [Fact]
+    [Test]
     public static async Task ReceiveMessage()
     {
         // arrange
@@ -28,6 +29,6 @@ public static class Tests
         }
 
         // assert
-        Assert.Equal(sent.Int32Field, received?.Int32Field);
+        Assert.That(received?.Int32Field, Is.EqualTo(sent.Int32Field));
     }
 }


### PR DESCRIPTION
Moving things closer to what we use for testing seems to be a good principle to follow. No hard feelings though if we decide to leave things as is.